### PR TITLE
mcu_timer: include <cstring>

### DIFF
--- a/src/backend/mcu_timer.cpp
+++ b/src/backend/mcu_timer.cpp
@@ -33,6 +33,7 @@
  */
 #include "mcu_timer.h"
 #include "mcu.h"
+#include <cstring>
 #include <cstdint>
 
 enum {


### PR DESCRIPTION
Building with gcc 14.2.1 fails when compiling mcu_timer:

```
[...]Nuked-SC55/src/backend/mcu_timer.cpp: In function 'void TIMER_NotifyRomsetChange(mcu_timer_t&)':
[...]Nuked-SC55/src/backend/mcu_timer.cpp:318:5: error: 'memcpy' was not declared in this scope
  318 |     memcpy(timer.frt_step_table, FRT_STEP_TABLE, sizeof(frt_step_table_type));
      |     ^~~~~~
```

```
[...]Nuked-SC55/src/backend/mcu_timer.cpp:36:1: note: 'memcpy' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
   35 | #include "mcu.h"
  +++ |+#include <cstring>
   36 | #include <cstdint>
```
